### PR TITLE
adding a getReferents method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,25 @@ function Genius(accessToken) {
   };
 
   /**
+   * Look up all referents/annotations associated with a song on Genius.
+   * You can pass in song_id, created_by_id, or web_page_id, as well as text_format
+   * @param  {Object}   options  The possible options e.g. text_format
+   * @param  {Function} callback The function to call once the song data is
+   *  available.
+   * @see https://docs.genius.com/#referents-h2
+   * @example
+   * getReferents({song_id: 378195, text_format: 'plain'}, function (error, song) { });
+   */
+  this.getReferents = function(options, callback) {
+
+    var request = {
+      url: "/referents",
+      qs: options
+    };
+    _makeRequest(request, callback);
+  }
+
+  /**
    * Look up an annotation.
    * @param  {String}   annotationId The annotation's id.
    * @param  {Object}   options      The possible options e.g. text_format

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,10 @@ geniusClient.getArtistSongs("16775", {"page": "1", "per_page": "10"},
   function (error, songs) {
   });
 
+// Look up all referents/annotations for a song.
+geniusClient.getReferents({"song_id": "378195", "text_format": "plain"}, function (error, results) {
+});
+
 // Search Genius.
 geniusClient.search("Kendrick Lamar", function (error, results) {
 });


### PR DESCRIPTION
Love this module, man! Found it really useful.

I had to find a work-around to grab referents, though, so I figured I'd contribute a getReferents method to your node-genius module. 
