### PR TITLE
Better error handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,10 +15,21 @@ function Genius(accessToken) {
     });
 
     baseRequest(options, function(error, response) {
-      if (response.statusCode > 399) {
-        callback(response.body);
+      // if there's an error, pass it to callback, null for results.
+      if(error){
+        callback(error, null);
         return;
       }
+      // if internet is disconnected then the response object will be undefined,
+      // throwing a undefined property error, which is statusCode.
+      else if (response.statusCode > 399) {
+        // this will work if internet is CONNECTED,
+        // and there's a server error like genius.com goes down or something like that
+        // still an error though. so null for results
+        callback(response.body, null);
+        return;
+      }
+      // if nothing goes wrong then return the response
       callback(null, response.body);
     });
   }


### PR DESCRIPTION
If you use the the module without the internet disconnected, there will be no response object. So, I tried to fix that.

This was the error you get when you try to run the module without internet. Not so pretty 👎 
```
if (response.statusCode > 399) {
                        ^
TypeError: Cannot read property 'statusCode' of undefined
    at Request._callback (/Users/candh/Desktop/test/node_modules/node-genius/lib/index.js:21:25)
    at self.callback (/Users/candh/Desktop/test/node_modules/request/request.js:186:22)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at Request.onRequestError (/Users/candh/Desktop/test/node_modules/request/request.js:845:8)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at TLSSocket.socketErrorListener (_http_client.js:310:9)
    at emitOne (events.js:96:13)
    at TLSSocket.emit (events.js:188:7)
```